### PR TITLE
UI微調整: ボタン配色固定/短い名称ツールチップ/端部軌道無効化/感度クリック化/フォーカス色修正/アニメ範囲選択廃止

### DIFF
--- a/animation.js
+++ b/animation.js
@@ -7,89 +7,30 @@
 // submission requirement and that "animated GIFs are now banned in
 // competition anyway, so there's probably no demand for this" - given that
 // admission, this port swaps the bitmap-sequence + external-tool workflow
-// for a single WebM file recorded directly in the browser (MediaRecorder),
-// which needs no extra dependency and no external assembly step. The
-// two-click rectangle selection gesture itself is kept as-is.
+// for a single WebM file recorded directly from the canvas (MediaRecorder).
+//
+// The original's two-click rectangle selection is dropped in favor of just
+// recording the canvas as currently drawn (no separate crop step, no crop
+// canvas or per-frame copy loop needed) - simpler, and the user can already
+// pan/zoom the view to frame whatever they want before recording.
 
 const AnimationCapture = (() => {
-    function normalizeRect(a, b) {
-        return {
-            x: Math.min(a.x, b.x), y: Math.min(a.y, b.y),
-            w: Math.max(1, Math.abs(a.x - b.x)), h: Math.max(1, Math.abs(a.y - b.y)),
-        };
-    }
-
-    /** Two-click rectangle picker over `container` (CSS pixel space), Escape cancels. */
-    function pickRectangle(container, rectEl) {
-        return new Promise((resolve) => {
-            let p1 = null;
-
-            const toLocal = (e) => {
-                const r = container.getBoundingClientRect();
-                return { x: e.clientX - r.left, y: e.clientY - r.top };
-            };
-            const onDown = (e) => {
-                const p = toLocal(e);
-                if (!p1) {
-                    p1 = p;
-                    rectEl.style.display = 'block';
-                    Object.assign(rectEl.style, { left: `${p.x}px`, top: `${p.y}px`, width: '0px', height: '0px' });
-                } else {
-                    const rect = normalizeRect(p1, p);
-                    cleanup();
-                    resolve(rect);
-                }
-            };
-            const onMove = (e) => {
-                if (!p1) return;
-                const norm = normalizeRect(p1, toLocal(e));
-                Object.assign(rectEl.style, { left: `${norm.x}px`, top: `${norm.y}px`, width: `${norm.w}px`, height: `${norm.h}px` });
-            };
-            const onKey = (e) => { if (e.key === 'Escape') { cleanup(); resolve(null); } };
-            function cleanup() {
-                container.removeEventListener('pointerdown', onDown);
-                container.removeEventListener('pointermove', onMove);
-                window.removeEventListener('keydown', onKey);
-                rectEl.style.display = 'none';
-            }
-            container.addEventListener('pointerdown', onDown);
-            container.addEventListener('pointermove', onMove);
-            window.addEventListener('keydown', onKey);
-        });
-    }
-
     /**
      * Records exactly one revolution (60000/roll ms, matching the resol
-     * frames-per-revolution the original sampled) of the selected canvas
-     * region to a WebM blob. Temporarily forces rotation on if it was
-     * stopped, restoring the previous state afterward.
+     * frames-per-revolution the original sampled) of the canvas exactly as
+     * currently drawn/framed to a WebM blob. Temporarily forces rotation on
+     * if it was stopped, restoring the previous state afterward.
      */
-    async function recordRegion(canvas, sim, rect, dpr) {
+    async function recordCanvas(canvas, sim) {
         if (!window.MediaRecorder) {
             throw new Error('このブラウザは動画録画(MediaRecorder)に対応していません。');
         }
 
-        const cropCanvas = document.createElement('canvas');
-        cropCanvas.width = Math.round(rect.w * dpr);
-        cropCanvas.height = Math.round(rect.h * dpr);
-        const cropCtx = cropCanvas.getContext('2d');
-
         const wasRunning = sim.menu.mstop.value;
         sim.menu.mstop.value = true;
 
-        let raf;
-        const copyFrame = () => {
-            cropCtx.drawImage(
-                canvas,
-                Math.round(rect.x * dpr), Math.round(rect.y * dpr), Math.round(rect.w * dpr), Math.round(rect.h * dpr),
-                0, 0, cropCanvas.width, cropCanvas.height
-            );
-            raf = requestAnimationFrame(copyFrame);
-        };
-        raf = requestAnimationFrame(copyFrame);
-
         try {
-            const stream = cropCanvas.captureStream(30);
+            const stream = canvas.captureStream(30);
             if (!stream) throw new Error('captureStream() が利用できませんでした。');
 
             const mimeType = ['video/webm;codecs=vp9', 'video/webm;codecs=vp8', 'video/webm']
@@ -112,30 +53,22 @@ const AnimationCapture = (() => {
             });
 
             if (blob.size === 0) {
-                throw new Error('録画データが空でした（キャンバスが非表示/最小化中だった可能性があります）。タブを表示したまま再度お試し下さい。');
+                throw new Error('録画データが空でした（タブが非表示/最小化中だった可能性があります）。タブを表示したまま再度お試し下さい。');
             }
 
             return blob;
         } finally {
-            cancelAnimationFrame(raf);
             sim.menu.mstop.value = wasRunning;
         }
     }
 
-    /** Full flow: prompt, pick rectangle, record, trigger a single-file download. */
-    async function run({ canvas, canvasWrap, selectRectEl, sim, graphics, ui }) {
-        ui.log('保存範囲を2回のクリックで示してください。キャンセルはEscキーです。');
-        const rect = await pickRectangle(canvasWrap, selectRectEl);
-        if (!rect || rect.w < 4 || rect.h < 4) {
-            ui.log('動画出力をキャンセルしました。');
-            return;
-        }
+    /** Full flow: record the current canvas, trigger a single-file download. */
+    async function run({ canvas, sim, ui }) {
         ui.log('録画中… (1回転分)');
-        const dpr = window.devicePixelRatio || 1;
 
         let blob;
         try {
-            blob = await recordRegion(canvas, sim, rect, dpr);
+            blob = await recordCanvas(canvas, sim);
         } catch (e) {
             ui.log(`動画の録画に失敗しました: ${e.message}`);
             return;

--- a/index.html
+++ b/index.html
@@ -32,20 +32,25 @@
         #main-column { display: flex; flex-direction: column; gap: 8px; flex: 1 1 640px; min-width: 320px; max-width: 900px; }
         #canvas-wrap { position: relative; border: 1px solid var(--border); border-radius: 4px; overflow: hidden; background: var(--canvas-fallback); aspect-ratio: 4 / 3; }
         #main-canvas { width: 100%; height: 100%; display: block; touch-action: none; cursor: crosshair; }
-        #select-rect { position: absolute; border: 1px dashed #fff; background: rgba(255,255,255,0.15); pointer-events: none; display: none; }
 
         #toolbar { display: flex; flex-wrap: wrap; gap: 4px; padding: 6px; background: var(--panel); border: 1px solid var(--border); border-radius: 4px; }
         #hidden-mode-row { display: flex; flex-wrap: wrap; gap: 4px; padding: 4px 6px; background: var(--panel); border: 1px solid var(--border); border-radius: 4px; }
         #hidden-mode-row.hidden { display: none; }
         #hidden-mode-row .icon-btn { font-size: 11px; }
 
+        /* Buttons intentionally do NOT follow the light/dark theme vars
+           above - same fixed dark-gray/outline/blue look in both modes, so
+           the toolbar doesn't get harder to read against a light page. */
         .icon-btn {
-            background: var(--surface); color: var(--text); border: 1px solid var(--border); border-radius: 4px;
+            background: #333333; color: #e8e8e8; border: 1px solid #3a3a3a; border-radius: 4px;
             padding: 5px 9px; cursor: pointer; font-size: 13px; line-height: 1.2; white-space: nowrap;
             display: inline-flex; align-items: center; gap: 6px;
         }
-        .icon-btn:hover { background: var(--surface-hover); }
-        .icon-btn.active { background: var(--accent); color: #ffffff; border-color: var(--accent); }
+        .icon-btn:hover { background: #4ea1ff; color: #08243d; }
+        .icon-btn.active { border: 2px solid #4ea1ff; padding: 4px 8px; }
+        .icon-btn.active:hover { background: #4ea1ff; color: #08243d; }
+        .icon-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+        .icon-btn:disabled:hover { background: #333333; color: #e8e8e8; }
         .icon-btn .icon-img { width: 20px; height: 20px; image-rendering: pixelated; flex: none; }
         .icon-btn .icon-emoji { display: inline-flex; align-items: center; justify-content: center; font-size: 16px; line-height: 1; }
         .icon-btn .icon-label { white-space: nowrap; }
@@ -67,7 +72,7 @@
         .param-row { display: flex; align-items: center; gap: 6px; margin-bottom: 2px; padding: 3px 4px; border-radius: 3px; cursor: ns-resize; user-select: none; }
         .param-row:hover { background: var(--surface-hover); }
         .param-row label { flex: 1 1 auto; font-size: 12px; }
-        .param-row .sensitivity { display: flex; gap: 1px; width: 12px; }
+        .param-row .sensitivity { display: flex; gap: 1px; width: 12px; cursor: pointer; }
         .param-row .sensitivity i { flex: 1; height: 10px; background: var(--border); border-radius: 1px; }
         .param-row .sensitivity i.on { background: var(--accent); }
         .param-row .value-chip { min-width: 68px; text-align: right; font-variant-numeric: tabular-nums; font-size: 12px; padding: 1px 4px; border-radius: 3px; background: var(--input-bg); border: 1px solid var(--border); }
@@ -99,7 +104,6 @@
         <div id="hidden-mode-row"></div>
         <div id="canvas-wrap">
             <canvas id="main-canvas"></canvas>
-            <div id="select-rect"></div>
         </div>
         <div id="help-bar" class="persistent"></div>
         <div id="log-container"></div>

--- a/main.js
+++ b/main.js
@@ -163,10 +163,7 @@ window.onload = () => {
     }
 
     async function startAnimationCapture() {
-        await AnimationCapture.run({
-            canvas, canvasWrap: document.getElementById('canvas-wrap'),
-            selectRectEl: document.getElementById('select-rect'), sim, graphics, ui,
-        });
+        await AnimationCapture.run({ canvas, sim, ui });
     }
 
     const ui = new UI(sim, graphics, {

--- a/simulation.js
+++ b/simulation.js
@@ -210,6 +210,16 @@ class Hecken {
         return this.bgColor > 128 ? 'rgb(200,200,200)' : 'rgb(50,50,50)';
     }
 
+    /**
+     * Parameter-hover highlight color (hecken.h's hardcoded white `focuced`,
+     * hecken.h:253 etc). The original always drew on a near-black canvas so
+     * white always had contrast; this port supports a light background too,
+     * so the highlight flips to black there instead of disappearing.
+     */
+    focusedColor() {
+        return this.bgColor > 128 ? 'rgb(0,0,0)' : 'rgb(255,255,255)';
+    }
+
     // --- hecken::correct(), hecken.h:916-932 --------------------------------
     // Called once per frame from proceed(). `g` is passed in so the display
     // scale (owned by Graphics, see file header) can be clamped alongside
@@ -343,7 +353,7 @@ class Hecken {
 
     // --- hecken::draw(), hecken.h:251-291 ------------------------------------
     draw(g, color, gray) {
-        const focused = '#ffffff';
+        const focused = this.focusedColor();
         const f = this.focus;
 
         g.line(this.crank, this.crankjoint, f.crankr ? focused : (this.dxfcrank ? gray : color));
@@ -398,7 +408,7 @@ class Hecken {
             this.ground = new Point(0, 0);
 
             if (this.menu.mpara.value) {
-                const focused = '#ffffff';
+                const focused = this.focusedColor();
                 // hecken.h:325-326 also highlights `crank` via tcrankx/
                 // tcranky, but those table rows are never initialized in
                 // initInterface (crank position isn't user-editable - see

--- a/ui.js
+++ b/ui.js
@@ -27,7 +27,6 @@ class UI {
         this.modalButtons = document.getElementById('modal-buttons');
         this.canvasWrap = document.getElementById('canvas-wrap');
         this.canvas = document.getElementById('main-canvas');
-        this.selectRect = document.getElementById('select-rect');
         this.fileInput = document.getElementById('file-input');
         this.dxfFileInput = document.getElementById('dxf-file-input');
 
@@ -164,7 +163,7 @@ class UI {
      * viewing the optimized curve (inviting a click to switch to DXF) and
      * the "optimize" icon while viewing DXF (hecken.h:706).
      */
-    _makeButton(container, { text, help, onClick, toggleGetter, activeClass = 'active', icon, iconOn, emoji, emojiOn }) {
+    _makeButton(container, { text, help, onClick, toggleGetter, activeClass = 'active', icon, iconOn, emoji, emojiOn, disabledGetter }) {
         const btn = document.createElement('button');
         btn.className = 'icon-btn';
         btn.type = 'button';
@@ -191,11 +190,17 @@ class UI {
 
         const render = () => {
             const active = toggleGetter ? !!toggleGetter() : false;
-            label.textContent = typeof text === 'function' ? text() : text;
+            const name = typeof text === 'function' ? text() : text;
+            label.textContent = name;
             if (toggleGetter) btn.classList.toggle(activeClass, active);
-            if (help) btn.title = typeof help === 'function' ? help() : help;
+            // The native tooltip (what actually appears "when pointing at"
+            // an icon) shows the short function name - the same text this
+            // button used before icons hid it (see class header) - while
+            // the persistent help bar below keeps the longer description.
+            btn.title = name;
             if (img) img.src = `icons/${(active && iconOn) ? iconOn : icon}`;
             if (emojiSpan) emojiSpan.textContent = (active && emojiOn) ? emojiOn : emoji;
+            if (disabledGetter) btn.disabled = !!disabledGetter();
         };
         render();
         btn.addEventListener('click', (e) => onClick(e, render));
@@ -242,21 +247,21 @@ class UI {
             },
         });
         this._makeButton(this.toolbar, {
-            text: () => (sim.menu.mstop.value ? '回転停止' : '回転開始'),
+            text: () => (sim.menu.mstop.value ? '停止' : '再生'),
             icon: 'start.png', iconOn: 'stop.png',
             help: '調整をする際には回転を停止させホイールで角度を変えると確認しやすいです',
             toggleGetter: () => sim.menu.mstop.value,
             onClick: (e, render) => { sim.menu.mstop.value = !sim.menu.mstop.value; render(); },
         });
         this._makeButton(this.toolbar, {
-            text: () => (sim.menu.mturn.value ? '反時計回りにする' : '時計回りにする'),
+            text: () => (sim.menu.mturn.value ? '反時計回り' : '時計回り'),
             icon: 'lturn.png', iconOn: 'rturn.png',
             help: '回転方向を切替えます',
             toggleGetter: () => sim.menu.mturn.value,
             onClick: (e, render) => { sim.menu.mturn.value = !sim.menu.mturn.value; render(); },
         });
         this._makeButton(this.toolbar, {
-            text: () => (sim.dxf ? '最適化曲線表示にする' : 'DXF表示にする'),
+            text: () => (sim.dxf ? '最適化曲線表示' : 'DXF表示'),
             // hecken.h:706 - icon follows the same "shows the action" convention
             // as the caption: DXF-icon while viewing the curve, opt-icon while viewing DXF.
             icon: 'dxf.png', iconOn: 'opt.png',
@@ -276,16 +281,22 @@ class UI {
         });
 
         this._makeButton(this.toolbar, {
-            text: '端部軌道を表示', icon: 'orbit.png', help: '最適化曲線の端部軌道を表示します（DXF時には表示されません）',
-            onClick: () => sim.toggleBothLegOrbits(),
+            text: () => (sim.exist_frontleg_orbit || sim.exist_rearleg_orbit ? '端部軌道を隠す' : '端部軌道を表示'),
+            icon: 'orbit.png',
+            help: () => (sim.dxf
+                ? '最適化曲線の端部軌道です。DXF表示中は表示対象がないため無効です。'
+                : '最適化曲線の端部軌道を表示します'),
+            toggleGetter: () => sim.exist_frontleg_orbit || sim.exist_rearleg_orbit,
+            disabledGetter: () => sim.dxf,
+            onClick: (e, render) => { sim.toggleBothLegOrbits(); render(); },
         });
         this._makeButton(this.toolbar, {
             text: '動画出力', icon: 'anime.png',
-            help: '範囲を選択してWebM動画として出力します',
+            help: '現在の描画範囲をそのままWebM動画として出力します',
             onClick: () => this.callbacks.startAnimationCapture(),
         });
         this._makeButton(this.toolbar, {
-            text: () => (document.body.classList.contains('dark') ? 'ライトモードにする' : 'ダークモードにする'),
+            text: () => (document.body.classList.contains('dark') ? 'ライトモード' : 'ダークモード'),
             emoji: '🌙', emojiOn: '☀',
             help: '画面配色をダーク/ライトで切替えます',
             toggleGetter: () => document.body.classList.contains('dark'),
@@ -565,6 +576,18 @@ class UI {
             [...sensitivity.children].forEach((el, idx) => el.classList.toggle('on', idx < count));
         };
         updateSensitivity();
+
+        // The sensitivity indicator is its own click target for cycling
+        // magnitude (mid->high->low->mid) - not a wheel target, so scrolling
+        // while positioned over the dots still changes the value like the
+        // rest of the row, not the sensitivity (middle-click anywhere in the
+        // row still works too, kept as a power-user shortcut).
+        sensitivity.addEventListener('click', (e) => {
+            e.stopPropagation();
+            this._rowState.set(def.key, modeCycle[this._rowState.get(def.key)]);
+            updateSensitivity();
+        });
+        sensitivity.addEventListener('wheel', (e) => e.stopPropagation());
 
         const applyStep = (sign) => {
             const magni = def.magni ?? 1;


### PR DESCRIPTION
## Summary
- アイコンボタンをライト/ダーク共通の固定配色に(通常=灰/ポイント時=青/押下中=青い縁取り)
- ホバー時のツールチップを短い機能名に変更(回転開始/停止→再生/停止)
- 「端部軌道を表示」はDXF表示中は無効化、押下状態を縁取りで表示
- 感度インジケーター(青3本線)をクリックで切替、ホイール対象からは除外
- パラメータホバーのフォーカスハイライト色を背景の明暗に応じて自動選択(ライトモードで見えなかった問題を修正)
- 動画出力の範囲選択を廃止し、現在の描画範囲をそのまま録画

## Test plan
- [x] npm test (51件)成功
- [x] ローカルで各項目を実機確認(canvasピクセル直接検証含む)
- [x] コンソールエラー0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014koZZomUs8mXdmwsR3yWup