### PR TITLE
フッターロゴの隣にGitHub/Xアイコンを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,13 +93,14 @@
 
         input[type=file] { display: none; }
 
-        #site-footer { flex-basis: 100%; text-align: center; padding: 8px 0 2px; }
-        #site-footer a { display: inline-block; opacity: 0.8; }
+        #site-footer { flex-basis: 100%; display: flex; align-items: center; justify-content: center; gap: 36px; padding: 8px 0 2px; }
+        #site-footer a { display: inline-flex; align-items: center; opacity: 0.8; }
         #site-footer a:hover { opacity: 1; }
         #site-footer .footer-logo { height: 78px; width: auto; display: block; }
         #site-footer .footer-logo-dark { display: none; }
         body.dark #site-footer .footer-logo-light { display: none; }
         body.dark #site-footer .footer-logo-dark { display: block; }
+        #site-footer .footer-icon { width: 36px; height: 36px; fill: var(--text); display: block; }
     </style>
 </head>
 <body>
@@ -124,6 +125,12 @@
         <a href="https://sin1.studio/" target="_blank" rel="noopener" aria-label="sin1.studio トップページへ">
             <img class="footer-logo footer-logo-light" src="sss_logo_3x1_B.png" alt="sin1's studio">
             <img class="footer-logo footer-logo-dark" src="sss_logo_white.png" alt="sin1's studio">
+        </a>
+        <a href="https://github.com/sin1n24/Links" target="_blank" rel="noopener" aria-label="GitHubリポジトリ">
+            <svg class="footer-icon" viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+        </a>
+        <a href="https://x.com/sin1west" target="_blank" rel="noopener" aria-label="X (旧Twitter)">
+            <svg class="footer-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
         </a>
     </footer>
 


### PR DESCRIPTION
## Summary
- フッターのsin1.studioロゴの右にGitHub/Xの2アイコンを追加
- GitHubはリポジトリ(https://github.com/sin1n24/Links)、Xはhttps://x.com/sin1westへリンク
- アイコンはvar(--text)で塗りつぶし、ライト/ダーク両対応。ロゴ・アイコン間は36pxの間隔

## Test plan
- [x] npm test (51件)成功
- [x] ローカルでリンク先・アイコン色・間隔をDOM検証、スクリーンショットで見た目確認
- [x] コンソールエラー0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014koZZomUs8mXdmwsR3yWup